### PR TITLE
[Add] 로그인 로직 분리

### DIFF
--- a/src/main/java/com/example/holaserver/Auth/Dto/KakaoLoginResponse.java
+++ b/src/main/java/com/example/holaserver/Auth/Dto/KakaoLoginResponse.java
@@ -9,34 +9,20 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class KakaoLoginResponse {
-    private Long id;
     private String name;
     private String email;
     private String imgPath;
-    private Type type;
-    private String tokenType;
-    private String accessToken;
+    private String oauthIdentity;
+    private String jwt;
     private String refreshToken;
 
-    @Builder
-    public KakaoLoginResponse(Long id, String name, String email, String imgPath, Type type, String tokenType, String accessToken, String refreshToken) {
-        this.id = id;
-        this.name = name;
-        this.email = email;
-        this.imgPath = imgPath;
-        this.type = type;
-        this.tokenType = tokenType;
-        this.accessToken = accessToken;
-        this.refreshToken = refreshToken;
-    }
 
     @Builder
-    public KakaoLoginResponse(Long id, User user, String token){
-        this.id = id;
-        this.name = user.getName();
-        this.email = user.getEmail();
-        this.imgPath = user.getImgPath();
-        this.tokenType = user.getOauthType();
-        this.accessToken = token;
+    public KakaoLoginResponse(SocialUserInfoDto user,String oauthIdentity, String token){
+        this.name = user.getKakao_account().getProfile().getNickname();
+        this.email = user.getKakao_account().getEmail();
+        this.imgPath = user.getKakao_account().getProfile().getProfile_image_url();
+        this.oauthIdentity = oauthIdentity;
+        this.jwt = token;
     }
 }

--- a/src/main/java/com/example/holaserver/Auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/holaserver/Auth/JwtTokenProvider.java
@@ -63,10 +63,13 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String resolveToken(HttpServletRequest request) {
 
+    public String resolveToken(HttpServletRequest request) {
+        // TODO : oauth 로그인 시 필터 적용 안되게 바꾸기
         String token =  request.getHeader("Authorization");
-        return token.substring(7);
+        if(token != null)
+            return token.substring(7);
+        else return null;
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/example/holaserver/Auth/JwtTokenProvider.java
+++ b/src/main/java/com/example/holaserver/Auth/JwtTokenProvider.java
@@ -67,9 +67,8 @@ public class JwtTokenProvider {
     public String resolveToken(HttpServletRequest request) {
         // TODO : oauth 로그인 시 필터 적용 안되게 바꾸기
         String token =  request.getHeader("Authorization");
-        if(token != null)
-            return token.substring(7);
-        else return null;
+        if(token == null) return null;
+        return token.substring(7);
     }
 
     public boolean validateToken(String token) {

--- a/src/main/java/com/example/holaserver/Auth/OauthService.java
+++ b/src/main/java/com/example/holaserver/Auth/OauthService.java
@@ -39,23 +39,12 @@ public class OauthService {
         SocialUserInfoDto kakaoUserInfo = getKakaoUserInfo(accessToken);
         String oauthIdentity = Long.toString(kakaoUserInfo.getId());
         User kakaoUser;
-        Long savedUserIdx;
+        String token = null;
         if(findUser(oauthIdentity, "Kakao")){
             kakaoUser = userRepository.findByOauthIdentity(oauthIdentity);
-            savedUserIdx = kakaoUser.getId();
-        } else {
-            kakaoUser = User.builder()
-                    .name(kakaoUserInfo.getKakao_account().getProfile().getNickname())
-                    .email(kakaoUserInfo.getKakao_account().getEmail())
-                    .rating((byte) 1)
-                    .imgPath(kakaoUserInfo.getKakao_account().getProfile().getProfile_image_url())
-                    .oauthIdentity(oauthIdentity)
-                    .oauthType("Kakao")
-                    .build();
-            savedUserIdx = userRepository.save(kakaoUser).getId();
+            token = jwtTokenProvider.createToken(kakaoUser.getId());
         }
-        String token = jwtTokenProvider.createToken(savedUserIdx);
-        KakaoLoginResponse response = new KakaoLoginResponse(kakaoUserInfo.getId(), kakaoUser, token);
+        KakaoLoginResponse response = new KakaoLoginResponse(kakaoUserInfo, oauthIdentity, token);
         return response;
     }
 

--- a/src/main/java/com/example/holaserver/User/Dto/UserSaveBody.java
+++ b/src/main/java/com/example/holaserver/User/Dto/UserSaveBody.java
@@ -1,0 +1,13 @@
+package com.example.holaserver.User.Dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserSaveBody {
+    private String name;
+    private String email;
+    private String imgPath;
+    private String oauthIdentity;
+}

--- a/src/main/java/com/example/holaserver/User/UserController.java
+++ b/src/main/java/com/example/holaserver/User/UserController.java
@@ -6,6 +6,7 @@ import com.example.holaserver.Common.response.ResponseTemplate;
 import com.example.holaserver.User.Dto.BossSaveDto;
 import com.example.holaserver.User.Dto.ProfileEditBody;
 import com.example.holaserver.User.Dto.UserInfoResponse;
+import com.example.holaserver.User.Dto.UserSaveBody;
 import javassist.NotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,12 @@ public class UserController {
         KakaoLoginResponse kaKaoLoginResponse = oauthService.kakaoLogin(code);
 
         return new ResponseTemplate<>(kaKaoLoginResponse, "로그인 성공");
+    }
+
+    @PostMapping("/user/kakao-login")
+    public ResponseTemplate<String> saveKakaoUser(@RequestBody UserSaveBody userSaveBody){
+        String token = userService.saveKakaoUser(userSaveBody);
+        return new ResponseTemplate<>(token, "회원가입 완료");
     }
 
     @GetMapping("/user/{nickname}")

--- a/src/main/java/com/example/holaserver/User/UserService.java
+++ b/src/main/java/com/example/holaserver/User/UserService.java
@@ -1,10 +1,12 @@
 package com.example.holaserver.User;
 
 import com.example.holaserver.Auth.AuthService;
+import com.example.holaserver.Auth.JwtTokenProvider;
 import com.example.holaserver.Auth.OauthService;
 import com.example.holaserver.User.Dto.BossSaveDto;
 import com.example.holaserver.User.Dto.ProfileEditBody;
 import com.example.holaserver.User.Dto.UserInfoResponse;
+import com.example.holaserver.User.Dto.UserSaveBody;
 import javassist.NotFoundException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,19 @@ public class UserService {
 
     private final OauthService oauthService;
     private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public String saveKakaoUser(UserSaveBody userSaveBody) {
+        User user = User.builder()
+                .name(userSaveBody.getName())
+                .email(userSaveBody.getEmail())
+                .rating((byte) 1)
+                .imgPath(userSaveBody.getImgPath())
+                .oauthIdentity(userSaveBody.getOauthIdentity())
+                .oauthType("Kakao")
+                .build();
+        return jwtTokenProvider.createToken(userRepository.save(user).getId());
+    }
 
     public UserInfoResponse loadMyInfo() throws NotFoundException{
         Long userId = authService.getPayloadByToken();


### PR DESCRIPTION
# Update
* 업데이트 목록 작성
## AS-IS
- 회원가입 로직으로 인해 api 분리 필요
## TO-BE
- Oauth와 회원가입 api 분리
## API Example
### BODY
```
{
    "name":String,
    "email":String,
    "imgPath":String,
    "oauthIdentity":String
}
```
### RESPONSE
```
{
    "message": "회원가입 완료",
    "status": 200,
    "data": {token}
}
```
# Checklist
- [ ] 스키마 업데이트
  - [ ] flyway 테스트 완료
  - [ ] 다이어그램 업데이트 완료
