### PR TITLE
스키마 업데이트 V4 및 CS 관련 API 생성

### DIFF
--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfaction.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfaction.java
@@ -1,0 +1,29 @@
+package com.example.holaserver.CustomerSatisfaction;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.security.Timestamp;
+
+@Entity
+@Getter
+@Where(clause = "removed_at IS NULL")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "customer_satisfaction")
+public class CustomerSatisfaction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+    @Column(name = "user_id")
+    private Long userId;
+    @Column(name = "type")
+    private Integer type;
+    @Column(name = "content")
+    private String content;
+    private Timestamp removedAt;
+
+
+}

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfaction.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfaction.java
@@ -1,6 +1,7 @@
 package com.example.holaserver.CustomerSatisfaction;
 
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Where;
@@ -25,5 +26,11 @@ public class CustomerSatisfaction {
     private String content;
     private Timestamp removedAt;
 
-
+    @Builder
+    public CustomerSatisfaction(Long userId, Integer type, String content) {
+        this.userId = userId;
+        this.type = type;
+        this.content = content;
+    }
 }
+

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionController.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionController.java
@@ -1,0 +1,4 @@
+package com.example.holaserver.CustomerSatisfaction;
+
+public class CustomerSatisfactionController {
+}

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionController.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionController.java
@@ -1,4 +1,21 @@
 package com.example.holaserver.CustomerSatisfaction;
 
+import com.example.holaserver.Common.response.ResponseTemplate;
+import com.example.holaserver.CustomerSatisfaction.DTO.CustomerSatisfactionBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
 public class CustomerSatisfactionController {
+    private final CustomerSatisfactionService customerSatisfactionService;
+    @PostMapping("/cs")
+    public ResponseTemplate<Map<String, Object>> customerSatisfactionSave(@RequestBody CustomerSatisfactionBody csBody) {
+        return new ResponseTemplate<>(customerSatisfactionService.saveCustomerSatisfaction(csBody), "CS 접수 성공");
+    }
+
 }

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionRepository.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionRepository.java
@@ -1,0 +1,6 @@
+package com.example.holaserver.CustomerSatisfaction;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerSatisfactionRepository extends JpaRepository<CustomerSatisfaction, Long> {
+}

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionService.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionService.java
@@ -1,0 +1,4 @@
+package com.example.holaserver.CustomerSatisfaction;
+
+public class CustomerSatisfactionService {
+}

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionService.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/CustomerSatisfactionService.java
@@ -1,4 +1,23 @@
 package com.example.holaserver.CustomerSatisfaction;
 
+import com.example.holaserver.Auth.AuthService;
+import com.example.holaserver.CustomerSatisfaction.DTO.CustomerSatisfactionBody;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.ui.ModelMap;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
 public class CustomerSatisfactionService {
+    private final CustomerSatisfactionRepository customerSatisfactionRepository;
+    private final AuthService authService;
+
+    public Map<String, Object> saveCustomerSatisfaction(CustomerSatisfactionBody csBody) {
+        authService.getPayloadByToken();
+        ModelMap result = new ModelMap();
+        result.addAttribute("customerSatisfactionId", customerSatisfactionRepository.save(csBody.createSaveCustomerSatisfactionBuilder(csBody)).getId());
+        return result;
+    }
 }

--- a/src/main/java/com/example/holaserver/CustomerSatisfaction/DTO/CustomerSatisfactionBody.java
+++ b/src/main/java/com/example/holaserver/CustomerSatisfaction/DTO/CustomerSatisfactionBody.java
@@ -1,0 +1,22 @@
+package com.example.holaserver.CustomerSatisfaction.DTO;
+
+import com.example.holaserver.CustomerSatisfaction.CustomerSatisfaction;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CustomerSatisfactionBody {
+    private Long userId;
+    private Integer type;
+    private String content;
+
+    public CustomerSatisfaction createSaveCustomerSatisfactionBuilder(CustomerSatisfactionBody csBody) {
+        return CustomerSatisfaction.builder()
+                .userId(csBody.getUserId())
+                .type(csBody.getType())
+                .content(csBody.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/example/holaserver/Review/DTO/ReviewSaveBody.java
+++ b/src/main/java/com/example/holaserver/Review/DTO/ReviewSaveBody.java
@@ -9,13 +9,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewSaveBody {
-    private Long userId;
     private Long storeId;
     private String reviewText;
     private String[] imgPath;
     private Long[] reviewTagIds;
 
-    public Review createReviewBuilder(){
+    public Review createReviewBuilder(Long userId){
         return Review.builder()
                 .storeId(storeId)
                 .userId(userId)

--- a/src/main/java/com/example/holaserver/Review/ReviewService.java
+++ b/src/main/java/com/example/holaserver/Review/ReviewService.java
@@ -51,6 +51,7 @@ public class ReviewService {
     }
 
     public List<ReviewByStoreResponse> findReviewAndRelationInfo(Long storeId) throws Exception {
+        authService.getPayloadByToken();
         List<Review> reviews = reviewRepository.findReviewsByStoreId(storeId);
         return reviews.stream().map(review -> new ReviewByStoreResponse(
                 review,

--- a/src/main/java/com/example/holaserver/Review/ReviewService.java
+++ b/src/main/java/com/example/holaserver/Review/ReviewService.java
@@ -39,7 +39,7 @@ public class ReviewService {
         /* 이미지나 리뷰 태그를 달지 않을 수도 있어서 null 예외처리 X */
         List<Long> imgReviewIds = imgReviewService.saveImgReview(reviewId, reviewSaveBody.getImgPath());
         List<Long> reviewTagLogIds = reviewTagLogService.saveReviewTagLog(
-                reviewSaveBody.getUserId(),
+                authService.getPayloadByToken(),
                 reviewSaveBody.getStoreId(),
                 reviewId,
                 reviewSaveBody.getReviewTagIds()
@@ -62,11 +62,7 @@ public class ReviewService {
 
 
     private Long saveReview(ReviewSaveBody reviewSaveBody){
-        return reviewRepository.save(reviewSaveBody.createReviewBuilder()).getId();
-    }
-
-    private List<Review> findReviewByStoreId(Long storeId) {
-        return reviewRepository.findReviewsByStoreId(storeId);
+        return reviewRepository.save(reviewSaveBody.createReviewBuilder(authService.getPayloadByToken())).getId();
     }
 
     public ReviewResponse loadReview(Long reviewId){

--- a/src/main/java/com/example/holaserver/User/UserController.java
+++ b/src/main/java/com/example/holaserver/User/UserController.java
@@ -26,7 +26,6 @@ public class UserController {
     private final UserService userService;
     private final OauthService oauthService;
     @GetMapping("/login/oauth/kakao")
-
     public ResponseTemplate<SocialLoginResponse> kakaoLogin(@RequestParam String accessToken){
         SocialLoginResponse socialLoginResponse = oauthService.kakaoLogin(accessToken);
         return new ResponseTemplate<>(socialLoginResponse, "로그인 성공");

--- a/src/main/resources/db/migration/V4__add_refill_guide.sql
+++ b/src/main/resources/db/migration/V4__add_refill_guide.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `store_refill_guide` (
+                         `id` int PRIMARY KEY AUTO_INCREMENT,
+                         `store_id` int not null,
+                         `img_path` varchar(100) not null,
+                         `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+                         `modified_at` TIMESTAMP NULL ON UPDATE CURRENT_TIMESTAMP,
+                         `removed_at` TIMESTAMP
+);


### PR DESCRIPTION
# Update
* `POST /api/cs` - CS 접수하기 API 업데이트
## AS-IS
- 리필 가이드 기능이 필요함
    - 가게에서 리필 가이드 버튼을 눌렀을 때 커스텀 이미지 N장이 필요
## TO-BE
- `store_refill_guide` 테이블 생성
    - PK, 가게 ID, img Path 필요.
    - N 장이 필요하기 때문에 테이블 따로 생성
## API Example
* (Optional)
# Checklist
- [x] 머지 대상 확인
- [x] 스키마 업데이트
  - [x] flyway 테스트 완료
  - [ ] 다이어그램 업데이트 완료
