### PR TITLE
[Update] 모델 removed_at IS NULL 추가 및 가게 정보 불러오기 API 이미지 업데이트

### DIFF
--- a/src/main/java/com/example/holaserver/Item/Item.java
+++ b/src/main/java/com/example/holaserver/Item/Item.java
@@ -3,12 +3,14 @@ package com.example.holaserver.Item;
 import com.example.holaserver.Common.BaseTimeEntity;
 import com.example.holaserver.Item.Enum.Unit;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Where(clause = "removed_at IS NULL")
 @Builder
 @Getter
 public class Item extends BaseTimeEntity {

--- a/src/main/java/com/example/holaserver/Review/ImgReview/ImgReview.java
+++ b/src/main/java/com/example/holaserver/Review/ImgReview/ImgReview.java
@@ -5,6 +5,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -13,6 +14,7 @@ import javax.persistence.Id;
 
 @Entity
 @Getter
+@Where(clause = "removed_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ImgReview extends BaseTimeEntity {
     @Id

--- a/src/main/java/com/example/holaserver/Review/Review.java
+++ b/src/main/java/com/example/holaserver/Review/Review.java
@@ -5,11 +5,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
 import javax.persistence.*;
 
 @Entity
 @Getter
 @Builder
+@Where(clause = "removed_at IS NULL")
 @NoArgsConstructor
 @AllArgsConstructor
 public class Review extends BaseTimeEntity {

--- a/src/main/java/com/example/holaserver/Store/CategoryStore/CategoryStore.java
+++ b/src/main/java/com/example/holaserver/Store/CategoryStore/CategoryStore.java
@@ -3,6 +3,7 @@ package com.example.holaserver.Store.CategoryStore;
 import com.example.holaserver.Common.BaseTimeEntity;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -12,6 +13,7 @@ import java.sql.Timestamp;
 
 @Entity
 @Getter
+@Where(clause = "removed_at IS NULL")
 @NoArgsConstructor
 public class CategoryStore extends BaseTimeEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/holaserver/Store/DTO/StoreResponse.java
+++ b/src/main/java/com/example/holaserver/Store/DTO/StoreResponse.java
@@ -1,7 +1,10 @@
 package com.example.holaserver.Store.DTO;
 
+import com.example.holaserver.Store.ImgStore.ImgStore;
 import com.example.holaserver.Store.Store;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 public class StoreResponse {
@@ -19,8 +22,9 @@ public class StoreResponse {
     private final String registrationNumber;
     private final Boolean isDayOff;
     private final Boolean isReady;
+    private final List<ImgStore> imgStore;
 
-    public StoreResponse(Store entity) {
+    public StoreResponse(Store entity, List<ImgStore> imgStore) {
         this.id = entity.getId();
         this.userId = entity.getUserId();
         this.name = entity.getName();
@@ -35,5 +39,6 @@ public class StoreResponse {
         this.registrationNumber = entity.getRegistrationNumber();
         this.isDayOff = entity.getIsDayOff();
         this.isReady = entity.getIsReady();
+        this.imgStore = imgStore;
     }
 }

--- a/src/main/java/com/example/holaserver/Store/ImgStore/ImgStore.java
+++ b/src/main/java/com/example/holaserver/Store/ImgStore/ImgStore.java
@@ -2,6 +2,7 @@ package com.example.holaserver.Store.ImgStore;
 
 import com.example.holaserver.Common.BaseTimeEntity;
 import lombok.*;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.*;
 
@@ -9,6 +10,7 @@ import javax.persistence.*;
 @Entity
 @Getter
 @Builder
+@Where(clause = "removed_at IS NULL")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class ImgStore extends BaseTimeEntity {

--- a/src/main/java/com/example/holaserver/Store/StoreController.java
+++ b/src/main/java/com/example/holaserver/Store/StoreController.java
@@ -1,10 +1,7 @@
 package com.example.holaserver.Store;
 
 import com.example.holaserver.Common.response.ResponseTemplate;
-import com.example.holaserver.Store.DTO.StoreBody;
-import com.example.holaserver.Store.DTO.StoreByLongitudeAndLatitudeInterface;
-import com.example.holaserver.Store.DTO.StoreByLongitudeAndLatitudeResponse;
-import com.example.holaserver.Store.DTO.StoreDeleteBody;
+import com.example.holaserver.Store.DTO.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -18,7 +15,7 @@ public class StoreController {
     private final StoreService storeService;
 
     @GetMapping("/user/store")
-    public ResponseTemplate<Store> storeDetailsByUserId() throws DataFormatException {
+    public ResponseTemplate<StoreResponse> storeDetailsByUserId() throws DataFormatException {
         return new ResponseTemplate<>(storeService.findStoreByUserId(), "가게 정보 불러오기 성공");
     }
 

--- a/src/main/java/com/example/holaserver/Store/StoreService.java
+++ b/src/main/java/com/example/holaserver/Store/StoreService.java
@@ -1,10 +1,7 @@
 package com.example.holaserver.Store;
 
 import com.example.holaserver.Auth.AuthService;
-import com.example.holaserver.Store.DTO.StoreBody;
-import com.example.holaserver.Store.DTO.StoreByLongitudeAndLatitudeInterface;
-import com.example.holaserver.Store.DTO.StoreByLongitudeAndLatitudeResponse;
-import com.example.holaserver.Store.DTO.StoreDeleteBody;
+import com.example.holaserver.Store.DTO.*;
 import com.example.holaserver.Store.ImgStore.ImgStore;
 import com.example.holaserver.Store.ImgStore.ImgStoreService;
 import lombok.RequiredArgsConstructor;
@@ -84,9 +81,12 @@ public class StoreService {
     }
 
     /* 해당 유저가 가지고 있는 가게 2개 이상일 시 Error */
-    public Store findStoreByUserId() {
-        return storeRepository.findByUserId(authService.getPayloadByToken())
+    public StoreResponse findStoreByUserId() {
+        authService.getPayloadByToken();
+        Store store = storeRepository.findByUserId(authService.getPayloadByToken())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.BAD_REQUEST, "이 유저가 속해있는 가게가 없습니다"));
+        List<ImgStore> imgStores = imgStoreService.findImgStoreByStoreId(store.getId());
+        return new StoreResponse(store, imgStores);
     }
 
     public List<StoreByLongitudeAndLatitudeResponse> findStoresByLongitudeAndLatitude(String longitude, String latitude) {


### PR DESCRIPTION
# Update
* 모델들에 `removed_at` IS NULL 옵션 추가
## AS-IS
- 가게정보 불러오기 API 에서 img store 불러오지 않는 이슈
## TO-BE
- img store 를 포함해 리턴함
## API Example
* (Optional)
# Checklist
- [x] 머지 대상 확인
- [ ] 스키마 업데이트
  - [ ] flyway 테스트 완료
  - [ ] 다이어그램 업데이트 완료
