### PR TITLE
[리필가이드] 리필가이드 기능 추가 및 Response 수정

### DIFF
--- a/src/main/java/com/example/holaserver/Store/DTO/StoreByLongitudeAndLatitudeResponse.java
+++ b/src/main/java/com/example/holaserver/Store/DTO/StoreByLongitudeAndLatitudeResponse.java
@@ -1,6 +1,7 @@
 package com.example.holaserver.Store.DTO;
 
 import com.example.holaserver.Store.ImgStore.ImgStore;
+import com.example.holaserver.Store.StoreRefillGuide.StoreRefillGuide;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -34,8 +35,9 @@ public class StoreByLongitudeAndLatitudeResponse {
     private Boolean isReady;
     private String distance;
     private List<ImgStore> imgStores;
+    private List<StoreRefillGuide> storeRefillGuides;
 
-    public StoreByLongitudeAndLatitudeResponse(StoreByLongitudeAndLatitudeInterface store, List<ImgStore> imgStores) throws JsonProcessingException {
+    public StoreByLongitudeAndLatitudeResponse(StoreByLongitudeAndLatitudeInterface store, List<ImgStore> imgStores, List<StoreRefillGuide> storeRefillGuides) throws JsonProcessingException {
         ObjectMapper mapper = new ObjectMapper();
         this.id = store.getId();
         this.userId = store.getUserId();
@@ -52,5 +54,6 @@ public class StoreByLongitudeAndLatitudeResponse {
         this.isReady = store.getIsReady();
         this.distance = store.getDistance();
         this.imgStores = imgStores;
+        this.storeRefillGuides = storeRefillGuides;
     }
 }

--- a/src/main/java/com/example/holaserver/Store/RefillGuide/RefillGuide.java
+++ b/src/main/java/com/example/holaserver/Store/RefillGuide/RefillGuide.java
@@ -1,0 +1,4 @@
+package com.example.holaserver.Store.RefillGuide;
+
+public class RefillGuide {
+}

--- a/src/main/java/com/example/holaserver/Store/RefillGuide/RefillGuide.java
+++ b/src/main/java/com/example/holaserver/Store/RefillGuide/RefillGuide.java
@@ -1,4 +1,0 @@
-package com.example.holaserver.Store.RefillGuide;
-
-public class RefillGuide {
-}

--- a/src/main/java/com/example/holaserver/Store/StoreController.java
+++ b/src/main/java/com/example/holaserver/Store/StoreController.java
@@ -2,6 +2,7 @@ package com.example.holaserver.Store;
 
 import com.example.holaserver.Common.response.ResponseTemplate;
 import com.example.holaserver.Store.DTO.*;
+import com.example.holaserver.Store.StoreRefillGuide.StoreRefillGuide;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,6 +43,8 @@ public class StoreController {
         return new ResponseTemplate<>(storeService.findStoresByLongitudeAndLatitude(longitude, latitude), "유저 위치 가게 정보 불러오기 성공");
     }
 
-
-
+    @GetMapping("/{storeId}/refill-guide")
+    public ResponseTemplate<List<StoreRefillGuide>> storeRefillGuideListByStoreId(@PathVariable Long storeId) {
+        return new ResponseTemplate<>(storeService.findRefillGuideByStoreId(storeId), "리필 가이드 불러오기 성공");
+    }
 }

--- a/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuide.java
+++ b/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuide.java
@@ -18,9 +18,7 @@ public class StoreRefillGuide extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
-    private Long stroeId;
-
+    private Long storeId;
     private String imgPath;
     private Timestamp removedAt;
 }

--- a/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuide.java
+++ b/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuide.java
@@ -1,0 +1,26 @@
+package com.example.holaserver.Store.StoreRefillGuide;
+
+import com.example.holaserver.Common.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+
+import javax.persistence.*;
+import java.sql.Timestamp;
+
+@Entity
+@Getter
+@Table(name="store_refill_guide")
+@Where(clause = "removed_at Is NULL")
+@NoArgsConstructor
+public class StoreRefillGuide extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long stroeId;
+
+    private String imgPath;
+    private Timestamp removedAt;
+}

--- a/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuideRepository.java
+++ b/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuideRepository.java
@@ -1,0 +1,9 @@
+package com.example.holaserver.Store.StoreRefillGuide;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface StoreRefillGuideRepository extends JpaRepository<StoreRefillGuide, Long> {
+    List<StoreRefillGuide> findStoreRefillGuidesByStoreId(Long storeId);
+}

--- a/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuideService.java
+++ b/src/main/java/com/example/holaserver/Store/StoreRefillGuide/StoreRefillGuideService.java
@@ -1,0 +1,15 @@
+package com.example.holaserver.Store.StoreRefillGuide;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class StoreRefillGuideService {
+    private final StoreRefillGuideRepository storeRefillGuideRepository;
+    public List<StoreRefillGuide> findAllByStoreId(Long storeId) {
+        return storeRefillGuideRepository.findStoreRefillGuidesByStoreId(storeId);
+    }
+}

--- a/src/main/java/com/example/holaserver/Store/StoreService.java
+++ b/src/main/java/com/example/holaserver/Store/StoreService.java
@@ -4,6 +4,9 @@ import com.example.holaserver.Auth.AuthService;
 import com.example.holaserver.Store.DTO.*;
 import com.example.holaserver.Store.ImgStore.ImgStore;
 import com.example.holaserver.Store.ImgStore.ImgStoreService;
+import com.example.holaserver.Store.StoreRefillGuide.StoreRefillGuide;
+import com.example.holaserver.Store.StoreRefillGuide.StoreRefillGuideRepository;
+import com.example.holaserver.Store.StoreRefillGuide.StoreRefillGuideService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,7 @@ import java.util.stream.Collectors;
 public class StoreService {
     private final StoreRepository storeRepository;
     private final ImgStoreService imgStoreService;
+    private final StoreRefillGuideService storeRefillGuideService;
     private final AuthService authService;
 
     @Transactional
@@ -105,8 +109,9 @@ public class StoreService {
 
         return stores.stream().map(store -> {
             List<ImgStore> imgStores = imgStoreService.findImgStoreByStoreId(store.getId());
+            List<StoreRefillGuide> storeRefillGuides = storeRefillGuideService.findAllByStoreId(store.getId());
             try {
-                return new StoreByLongitudeAndLatitudeResponse(store, imgStores);
+                return new StoreByLongitudeAndLatitudeResponse(store, imgStores, storeRefillGuides);
             } catch (JsonProcessingException e) {
                 throw new RuntimeException(e);
             }
@@ -115,5 +120,10 @@ public class StoreService {
 
     public Boolean existStoreById(Long storeId) {
         return storeRepository.existsStoreById(storeId);
+    }
+
+    public List<StoreRefillGuide> findRefillGuideByStoreId(Long storeId) {
+        authService.getPayloadByToken();
+        return storeRefillGuideService.findAllByStoreId(storeId);
     }
 }

--- a/src/main/java/com/example/holaserver/User/User.java
+++ b/src/main/java/com/example/holaserver/User/User.java
@@ -9,7 +9,7 @@ import javax.persistence.*;
 import java.sql.Timestamp;
 
 @Entity
-@Table(name="User")
+@Table(name="user")
 @Getter
 @Where(clause = "removed_at IS NULL")
 @AllArgsConstructor


### PR DESCRIPTION
# Update
* `GET /api/{storeId}/refill-guide` - API 업데이트
  * 기획 변경으로 사용되지는 않지만 기본 GET이라 우선 남겨둠
* `유저 정보 위치기반 가게 정보 가져오기` API 에서 리필 가이드 데이터 추가
  * https://www.notion.so/yapp-workspace/api-user-stores-4ac4fcff99354e1cb76b4246865573c5?pvs=4
## AS-IS
- (원인) 
## TO-BE
- (해결방안)
## API Example
* (Optional)
# Checklist
- [x] 머지 대상 확인
- [ ] 스키마 업데이트
  - [ ] flyway 테스트 완료
  - [ ] 다이어그램 업데이트 완료
